### PR TITLE
Adapt dialog to accept outside input

### DIFF
--- a/resources/views/components/dialog/close.blade.php
+++ b/resources/views/components/dialog/close.blade.php
@@ -4,7 +4,7 @@
 
 <x-button
     :$variant
-    @click="$refs.__dialog.close()"
+    @click="dialogOpen = false"
 >
     Close
 </x-button>

--- a/resources/views/components/dialog/content.blade.php
+++ b/resources/views/components/dialog/content.blade.php
@@ -1,4 +1,5 @@
 <dialog
+    wire:ignore.self
     x-effect="dialogOpen ? $el.showModal() : $el.close()"
     x-on:close.stop="dialogOpen = false"
     x-on:cancel.stop="dialogOpen = false"

--- a/resources/views/components/dialog/content.blade.php
+++ b/resources/views/components/dialog/content.blade.php
@@ -1,5 +1,7 @@
 <dialog
-    x-ref="__dialog"
+    x-effect="dialogOpen ? $el.showModal() : $el.close()"
+    x-on:close.stop="dialogOpen = false"
+    x-on:cancel.stop="dialogOpen = false"
     {{ $attributes->twMerge('w-full max-w-lg border bg-background p-6 shadow-lg  sm:rounded-lg transition-[translate,opacity,scale,overlay,display] [transition-behavior:allow-discrete] open:animate-in open:fade-in-0 open:zoom-in-95 animate-out duration-200 fade-out-0 zoom-out-95 backdrop:bg-black/80 backdrop:duration-300 backdrop:opacity-0 backdrop:transition-[opacity,display,overlay] backdrop:[transition-behavior:allow-discrete] open:backdrop:opacity-100 [@starting-style]:open:backdrop:opacity-0') }}
 >
     {{ $slot }}
@@ -8,7 +10,7 @@
         class="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
         variant="ghost"
         size="icon"
-        @click="$refs.__dialog.close()"
+        @click="dialogOpen = false"
     >
         <x-lucide-x class="size-4" />
         <span class="sr-only">Close</span>

--- a/resources/views/components/dialog/index.blade.php
+++ b/resources/views/components/dialog/index.blade.php
@@ -1,5 +1,6 @@
 <div
-    x-data
+    x-data="{ dialogOpen: false }"
+    x-modelable="dialogOpen"
     {{ $attributes->twMerge('') }}
 >
     {{ $slot }}

--- a/resources/views/components/dialog/trigger.blade.php
+++ b/resources/views/components/dialog/trigger.blade.php
@@ -4,7 +4,7 @@
 
 <x-button
     :$variant
-    @click="$refs.__dialog.showModal();"
+    @click="dialogOpen = true"
 >
     {{ $slot }}
 </x-button>


### PR DESCRIPTION
We encountered problems when using the dialog. The dialog was closed automatically, also we couldn't bind a show boolean value we control in our component. This PR fixes both issues, the former with `wire:ignore.self`, the latter with correct `x-data` usage throughout the dialog component.

`wire:ignore.self` because `showModal` adds an `open` attribute, which is removed during a Livewire update.