### PR TITLE
Add Fragments and as props to all trigger where necessary

### DIFF
--- a/resources/views/components/dialog/trigger.blade.php
+++ b/resources/views/components/dialog/trigger.blade.php
@@ -1,10 +1,10 @@
 @props([
-    'variant' => 'outline',
+    'as' => 'fragment',
 ])
-
-<x-button
-    :$variant
-    @click="$refs.__dialog.showModal();"
+<x-dynamic-component
+    :component="$as"
+    :$attributes
+    x-on:click="$refs.__dialog.showModal();"
 >
     {{ $slot }}
-</x-button>
+</x-dynamic-component>

--- a/resources/views/components/dropdown-menu/trigger.blade.php
+++ b/resources/views/components/dropdown-menu/trigger.blade.php
@@ -1,3 +1,10 @@
-<x-button x-dropdown-menu:button {{ $attributes }}>
+@props([
+    'as' => 'fragment',
+])
+<x-dynamic-component
+    :component="$as"
+    :$attributes
+    x-dropdown-menu:button
+>
     {{ $slot }}
-</x-button>
+</x-dynamic-component>

--- a/resources/views/components/fragment/index.blade.php
+++ b/resources/views/components/fragment/index.blade.php
@@ -1,0 +1,3 @@
+<div {{ $attributes->twMerge() }}>
+    {{ $slot }}
+</div>

--- a/resources/views/components/hover-card/trigger.blade.php
+++ b/resources/views/components/hover-card/trigger.blade.php
@@ -1,6 +1,10 @@
-<div
+@props([
+    'as' => 'fragment',
+])
+<x-dynamic-component
+    :component="$as"
+    :attributes="$attributes->twMerge('inline-flex')"
     x-hover-card:trigger
-    class="inline-flex"
 >
     {{ $slot }}
-</div>
+</x-dynamic-component>

--- a/resources/views/components/popover/trigger.blade.php
+++ b/resources/views/components/popover/trigger.blade.php
@@ -1,10 +1,14 @@
-<div
-    :id="$id('popover-trigger')"
+@props([
+    'as' => 'fragment',
+])
+<x-dynamic-component
+    :component="$as"
+    :attributes="$attributes->twMerge('inline-flex')"
+    ::id="$id('popover-trigger')"
     x-ref="popover-trigger"
     x-on:click="__open = !__open"
-    :aria-expanded="__open"
-    :aria-controls="$id('popover-trigger')"
-    {{ $attributes->twMerge('inline-flex')}}
+    ::aria-expanded="__open"
+    ::aria-controls="$id('popover-trigger')"
 >
     {{ $slot }}
-</div>
+</x-dynamic-component>

--- a/resources/views/components/sheet/trigger.blade.php
+++ b/resources/views/components/sheet/trigger.blade.php
@@ -1,3 +1,10 @@
-<div @click="open = ! open">
+@props([
+    'as' => 'fragment',
+])
+<x-dynamic-component
+    :component="$as"
+    :$attributes
+    x-on:click="open = ! open"
+>
     {{ $slot }}
-</div>
+</x-dynamic-component>

--- a/resources/views/components/tooltip/trigger.blade.php
+++ b/resources/views/components/tooltip/trigger.blade.php
@@ -1,6 +1,10 @@
-<div
+@props([
+    'as' => 'fragment',
+])
+<x-dynamic-component
+    :component="$as"
+    :attributes="$attributes->twMerge('inline-flex')"
     x-tooltip:trigger
-    class="inline-flex"
 >
     {{ $slot }}
-</div>
+</x-dynamic-component>


### PR DESCRIPTION
To have the probability to change the component of a trigger we introduce a fragment component which renders a div.
We add a new prop to all trigger where necessary called `as`, where we can pass a component name like `button`.
we can replace the following code:
```blade
<x-dialog.trigger>
    <x-button>
       Open Dialog
    </x-button>
</x-dialog.trigger>
```
with this:
```blade
<x-dialog.trigger as="button">
   Open Dialog
</x-dialog.trigger>
```
